### PR TITLE
refactor: create HttpService layer and StoriesService

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,6 +17,7 @@
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
-    "supabase"
+    "supabase",
+    "posthog"
   ]
 }

--- a/src/app/api/stories/auto-complete/route.ts
+++ b/src/app/api/stories/auto-complete/route.ts
@@ -1,0 +1,136 @@
+import { isNumber } from '@/utils/isNumber';
+import { createClient } from '@/utils/supabase/server';
+import { formatISO } from 'date-fns';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json();
+        const storyId = Number(body.storyId);
+        const roomId = Number(body.roomId);
+
+        // Input validation (Next.js best practice)
+        if (!Number.isInteger(storyId) || !Number.isInteger(roomId) || storyId <= 0 || roomId <= 0) {
+            return NextResponse.json(
+                { error: 'storyId and roomId must be positive integers' },
+                { status: 400 }
+            );
+        }
+
+        const supabase = await createClient();
+
+        // Batch query: Get story, active users, and votes in parallel (N+1 prevention)
+        const [storyResult, usersResult, votesResult] = await Promise.all([
+            supabase
+                .from('Stories')
+                .select('id, started_at, finished_at')
+                .eq('id', storyId)
+                .single(),
+            supabase
+                .from('UsersOnRooms')
+                .select('public_user_id')
+                .eq('room_id', roomId)
+                .eq('active', true),
+            supabase
+                .from('UsersOnStories')
+                .select('public_user_id, value')
+                .eq('story_id', storyId)
+        ]);
+
+        // Handle story errors
+        if (storyResult.error || !storyResult.data) {
+            return NextResponse.json(
+                { error: 'Story not found' },
+                { status: 404 }
+            );
+        }
+
+        const story = storyResult.data;
+
+        // Early return if story is already finished or not started
+        if (story.finished_at || !story.started_at) {
+            return NextResponse.json({
+                autoCompleted: false,
+                reason: story.finished_at ? 'already_finished' : 'not_started'
+            });
+        }
+
+        // Handle users error
+        if (usersResult.error) {
+            return NextResponse.json(
+                { error: 'Failed to fetch users' },
+                { status: 500 }
+            );
+        }
+
+        const activeUsers = usersResult.data || [];
+
+        // Need more than 1 active user for auto-complete
+        if (activeUsers.length <= 1) {
+            return NextResponse.json({
+                autoCompleted: false,
+                reason: 'not_enough_active_users'
+            });
+        }
+
+        // Handle votes error
+        if (votesResult.error) {
+            return NextResponse.json(
+                { error: 'Failed to fetch votes' },
+                { status: 500 }
+            );
+        }
+
+        const usersOnStory = votesResult.data || [];
+
+        // Check if all active users have voted
+        const allVoted = activeUsers.every(({ public_user_id }) =>
+            usersOnStory.some(
+                ({ public_user_id: voterId, value }) =>
+                    public_user_id === voterId && isNumber(value)
+            )
+        );
+
+        if (!allVoted) {
+            return NextResponse.json({
+                autoCompleted: false,
+                reason: 'not_all_voted'
+            });
+        }
+
+        // Atomic update with race condition protection:
+        // - Only updates if finished_at is NULL
+        // - Returns updated row to confirm it was actually updated
+        const { data: updatedStory, error: updateError } = await supabase
+            .from('Stories')
+            .update({ finished_at: formatISO(new Date()) })
+            .eq('id', storyId)
+            .is('finished_at', null)
+            .select('id')
+            .single();
+
+        if (updateError) {
+            // PGRST116 = no rows returned (already finished by another request)
+            if (updateError.code === 'PGRST116') {
+                return NextResponse.json({
+                    autoCompleted: false,
+                    reason: 'already_finished'
+                });
+            }
+            return NextResponse.json(
+                { error: 'Failed to stop story' },
+                { status: 500 }
+            );
+        }
+
+        return NextResponse.json({
+            autoCompleted: !!updatedStory
+        });
+    } catch (error) {
+        console.error('Auto-complete error:', error);
+        return NextResponse.json(
+            { error: 'Internal server error' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -1,0 +1,101 @@
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+interface RequestOptions<TBody = unknown> {
+    method?: HttpMethod;
+    body?: TBody;
+    headers?: Record<string, string>;
+}
+
+interface HttpResponse<TData> {
+    data: TData | null;
+    error: Error | null;
+    status: number;
+}
+
+export class HttpService {
+    private baseUrl: string;
+
+    constructor(baseUrl = '') {
+        this.baseUrl = baseUrl;
+    }
+
+    private async request<TData, TBody = unknown>(
+        endpoint: string,
+        options: RequestOptions<TBody> = {}
+    ): Promise<HttpResponse<TData>> {
+        const { method = 'GET', body, headers = {} } = options;
+
+        const url = `${this.baseUrl}${endpoint}`;
+
+        const requestInit: RequestInit = {
+            method,
+            headers: {
+                'Content-Type': 'application/json',
+                ...headers,
+            },
+        };
+
+        if (body !== undefined) {
+            requestInit.body = JSON.stringify(body);
+        }
+
+        try {
+            const response = await fetch(url, requestInit);
+            const data = await response.json();
+
+            if (!response.ok) {
+                return {
+                    data: null,
+                    error: new Error(data.error || 'Request failed'),
+                    status: response.status,
+                };
+            }
+
+            return {
+                data: data as TData,
+                error: null,
+                status: response.status,
+            };
+        } catch (error) {
+            return {
+                data: null,
+                error: error instanceof Error ? error : new Error('Unknown error'),
+                status: 0,
+            };
+        }
+    }
+
+    async get<TData>(endpoint: string, headers?: Record<string, string>): Promise<HttpResponse<TData>> {
+        return this.request<TData>(endpoint, { method: 'GET', headers });
+    }
+
+    async post<TData, TBody = unknown>(
+        endpoint: string,
+        body?: TBody,
+        headers?: Record<string, string>
+    ): Promise<HttpResponse<TData>> {
+        return this.request<TData, TBody>(endpoint, { method: 'POST', body, headers });
+    }
+
+    async put<TData, TBody = unknown>(
+        endpoint: string,
+        body?: TBody,
+        headers?: Record<string, string>
+    ): Promise<HttpResponse<TData>> {
+        return this.request<TData, TBody>(endpoint, { method: 'PUT', body, headers });
+    }
+
+    async patch<TData, TBody = unknown>(
+        endpoint: string,
+        body?: TBody,
+        headers?: Record<string, string>
+    ): Promise<HttpResponse<TData>> {
+        return this.request<TData, TBody>(endpoint, { method: 'PATCH', body, headers });
+    }
+
+    async delete<TData>(endpoint: string, headers?: Record<string, string>): Promise<HttpResponse<TData>> {
+        return this.request<TData>(endpoint, { method: 'DELETE', headers });
+    }
+}
+
+export const httpService = new HttpService();

--- a/src/services/StoriesService.ts
+++ b/src/services/StoriesService.ts
@@ -1,0 +1,27 @@
+import { httpService } from './HttpService';
+
+interface AutoCompleteRequest {
+    storyId: number;
+    roomId: number;
+}
+
+interface AutoCompleteResponse {
+    autoCompleted: boolean;
+    reason?: string;
+}
+
+export const storiesService = {
+    async checkAutoComplete(storyId: number, roomId: number): Promise<AutoCompleteResponse | null> {
+        const { data, error } = await httpService.post<AutoCompleteResponse, AutoCompleteRequest>(
+            '/api/stories/auto-complete',
+            { storyId, roomId }
+        );
+
+        if (error) {
+            console.error('Auto-complete check failed:', error);
+            return null;
+        }
+
+        return data;
+    },
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,2 @@
+export { HttpService, httpService } from './HttpService';
+export { storiesService } from './StoriesService';


### PR DESCRIPTION
## Summary
Extract generic HTTP client into reusable HttpService class with consistent error handling. Move story auto-complete check from RoomPage component to StoriesService for better separation of concerns. Remove duplicate isNumber utility from API route.

## Changes
- Create HttpService class for standardized fetch operations
- Create StoriesService for story-related API calls
- Refactor RoomPage to use storiesService.checkAutoComplete()
- Replace duplicate isNumber in route.ts with shared utility

## Test Plan
- [x] TypeScript compilation passes
- [x] Auto-complete functionality preserved
- [x] Service exports properly available