### PR TITLE
Fix duplicate members appearing in room member list

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -134,7 +134,8 @@ export const joinRoomAction = async (roomId: string) => {
             .select('*, user:Users(*)')
             .eq('room_id', Number(roomId))
             .eq('user_id', user.id)
-            .single(),
+            .limit(1)
+            .maybeSingle(),
         supabase.from('StoriesOnRooms')
             .select('*')
             .eq('room_id', Number(roomId))

--- a/src/components/RoomPage/RoomPage.service.ts
+++ b/src/components/RoomPage/RoomPage.service.ts
@@ -40,9 +40,13 @@ export class RoomPageService {
             return [];
         }
 
-        return users
+        const uniqueUsers = new Map<number, UserWithActivity>();
+        users
             .map(({ user, active, is_admin }) => ({ ...user, active, isAdmin: !!is_admin }))
-            .filter(user => user) as UserWithActivity[];
+            .filter(user => user)
+            .forEach((user) => uniqueUsers.set((user as UserWithActivity).id, user as UserWithActivity));
+
+        return Array.from(uniqueUsers.values());
     }
 
     async getStory() {
@@ -102,9 +106,10 @@ export class RoomPageService {
             .select('*, user:Users(*)')
             .eq('room_id', this.roomId)
             .eq('public_user_id', userId)
-            .single();
+            .limit(1)
+            .maybeSingle();
 
-        if (error) {
+        if (error || !data) {
             console.error('Error fetching member', error);
             return null;
         }

--- a/src/components/RoomPage/RoomPage.store.ts
+++ b/src/components/RoomPage/RoomPage.store.ts
@@ -103,8 +103,16 @@ export const reducer: Reducer<IState, IAction> = (state, action) => {
     switch (action.type) {
         case ActionTypes.USERS_FETCHED:
             return { ...state, users: action.payload, usersLoading: false };
-        case ActionTypes.USER_CREATED:
-            return { ...state, users: [...state.users, action.payload] };
+        case ActionTypes.USER_CREATED: {
+            const shallowCopy = [...state.users];
+            const userIdx = shallowCopy.findIndex(({ id }) => id === action.payload.id);
+            if (userIdx !== -1) {
+                shallowCopy.splice(userIdx, 1, action.payload);
+            } else {
+                shallowCopy.push(action.payload);
+            }
+            return { ...state, users: shallowCopy };
+        }
         case ActionTypes.USER_DELETED: {
             const shallowCopy = [...state.users];
             const userIdx = shallowCopy.findIndex(({ id }) => id === action.payload.id);
@@ -135,8 +143,18 @@ export const reducer: Reducer<IState, IAction> = (state, action) => {
             return { ...state, room: action.payload };
         case ActionTypes.USERS_ON_STORY_FETCHED:
             return { ...state, usersOnStory: action.payload, usersOnStoryLoading: false };
-        case ActionTypes.USER_ON_STORY_CREATED:
-            return { ...state, usersOnStory: [...state.usersOnStory, action.payload] };
+        case ActionTypes.USER_ON_STORY_CREATED: {
+            const shallowCopy = [...state.usersOnStory];
+            const userOnStoryIdx = shallowCopy.findIndex(({ public_user_id, story_id }) => {
+                return public_user_id === action.payload.public_user_id && story_id === action.payload.story_id;
+            });
+            if (userOnStoryIdx !== -1) {
+                shallowCopy.splice(userOnStoryIdx, 1, action.payload);
+            } else {
+                shallowCopy.push(action.payload);
+            }
+            return { ...state, usersOnStory: shallowCopy };
+        }
         case ActionTypes.USER_ON_STORY_UPDATED: {
             const shallowCopy = [...state.usersOnStory];
             const userOnStoryIdx = shallowCopy.findIndex(({ id }) => id === action.payload.id);


### PR DESCRIPTION
Fixes a rare bug where a user who kept the room page open without refreshing would see the same member listed 2-3 times.

The `USER_CREATED` and `USER_ON_STORY_CREATED` reducer cases now replace an existing entry instead of blindly appending, so redelivered Supabase realtime INSERT events (e.g. after a socket reconnect) can no longer duplicate members or votes. `RoomPageService.getUsers()` additionally dedupes members by user id, so pre-existing duplicate `UsersOnRooms` rows in the DB are hidden from the UI. The membership lookups in `getMember()` and `joinRoomAction` were switched from `.single()` to `.limit(1).maybeSingle()` so duplicate rows no longer error out and cause yet another row to be inserted on join.