### PR TITLE
Encrypt vote values with AES-GCM to hide numbers from devtools

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -234,6 +234,7 @@ export type Database = {
       UsersOnStories: {
         Row: {
           created_at: string
+          encrypted_value: string | null
           id: number
           public_user_id: number
           story_id: number
@@ -241,6 +242,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          encrypted_value?: string | null
           id?: number
           public_user_id: number
           story_id: number
@@ -248,6 +250,7 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          encrypted_value?: string | null
           id?: number
           public_user_id?: number
           story_id?: number

--- a/src/app/api/stories/auto-complete/route.ts
+++ b/src/app/api/stories/auto-complete/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: Request) {
                 .eq('active', true),
             supabase
                 .from('UsersOnStories')
-                .select('public_user_id, value')
+                .select('public_user_id, value, encrypted_value')
                 .eq('story_id', storyId)
         ]);
 
@@ -83,11 +83,13 @@ export async function POST(request: Request) {
 
         const usersOnStory = votesResult.data || [];
 
-        // Check if all active users have voted
+        // Check if all active users have voted. Votes are stored encrypted in
+        // `encrypted_value`; the plain `value` column only exists for legacy rows.
+        // Presence of either is enough here, the number itself is not needed.
         const allVoted = activeUsers.every(({ public_user_id }) =>
             usersOnStory.some(
-                ({ public_user_id: voterId, value }) =>
-                    public_user_id === voterId && isNumber(value)
+                ({ public_user_id: voterId, value, encrypted_value }) =>
+                    public_user_id === voterId && (!!encrypted_value || isNumber(value))
             )
         );
 

--- a/src/components/RoomPage/RoomPage.realtime.ts
+++ b/src/components/RoomPage/RoomPage.realtime.ts
@@ -1,6 +1,7 @@
 import { RoomPageService } from '@/components/RoomPage/RoomPage.service';
 import { Room, Story, StoryOnRoom, User, UserOnRoom, UserOnStory } from '@/types';
 import { RealtimeChannel } from '@supabase/realtime-js';
+import { decodeUserOnStory } from '@/utils/voteCipher';
 import { ActionTypes, DispatchType } from './RoomPage.store';
 
 export const realtime = ({
@@ -66,7 +67,7 @@ export const realtime = ({
                 if (userOnStory.story_id !== storyId) {
                     return;
                 }
-                dispatch({ type: ActionTypes.USER_ON_STORY_CREATED, payload: userOnStory });
+                dispatch({ type: ActionTypes.USER_ON_STORY_CREATED, payload: await decodeUserOnStory(userOnStory) });
             },
         )
         .on(
@@ -77,7 +78,7 @@ export const realtime = ({
                 if (userOnStory.story_id !== storyId) {
                     return;
                 }
-                dispatch({ type: ActionTypes.USER_ON_STORY_UPDATED, payload: userOnStory });
+                dispatch({ type: ActionTypes.USER_ON_STORY_UPDATED, payload: await decodeUserOnStory(userOnStory) });
             },
         )
         .on(

--- a/src/components/RoomPage/RoomPage.service.ts
+++ b/src/components/RoomPage/RoomPage.service.ts
@@ -1,6 +1,7 @@
 import { formatISO } from 'date-fns';
 import { Room, Story, UserWithActivity } from '@/types';
 import { createClient, SupabaseClient } from '@/utils/supabase/client';
+import { decodeUsersOnStory, encryptVote } from '@/utils/voteCipher';
 
 export class RoomPageService {
     supabase: SupabaseClient;
@@ -64,11 +65,15 @@ export class RoomPageService {
             .limit(1)
             .single();
 
-        if (Array.isArray(data?.story)) {
-            return data?.story?.[0] || null;
+        const story: Story | null = Array.isArray(data?.story)
+            ? (data?.story?.[0] as Story) || null
+            : (data?.story as Story) || null;
+
+        if (story?.users) {
+            story.users = await decodeUsersOnStory(story.users);
         }
 
-        return data?.story || null;
+        return story;
     }
 
     async getUsersOnStory(storyId: number) {
@@ -82,7 +87,7 @@ export class RoomPageService {
             return [];
         }
 
-        return usersOnStory;
+        return decodeUsersOnStory(usersOnStory);
     }
 
     async getUser(userId: number) {
@@ -159,12 +164,15 @@ export class RoomPageService {
     }
 
     async selectTime(storyId: number, userId: number, value: number) {
+        const encrypted_value = await encryptVote(value);
         return this.supabase
             .from('UsersOnStories')
             .upsert({
                 story_id: storyId,
                 public_user_id: userId,
-                value,
+                // Plain value is no longer stored; the number is only kept encrypted.
+                value: null,
+                encrypted_value,
             });
     }
 

--- a/src/utils/voteCipher.ts
+++ b/src/utils/voteCipher.ts
@@ -1,0 +1,111 @@
+import { UserOnStory } from '@/types';
+import { isNumber } from '@/utils/isNumber';
+
+/**
+ * Lightweight obfuscation of vote values.
+ *
+ * Votes are encrypted with AES-GCM before being written to `UsersOnStories`,
+ * so the raw numbers are not readable from the realtime websocket frames or
+ * REST responses in the browser devtools. A random IV is generated for every
+ * encryption, so the same vote produces a different ciphertext every time and
+ * cannot be matched by comparing payloads.
+ *
+ * This is intentionally NOT a security boundary: the key lives in the client
+ * bundle and anyone determined enough can decrypt the values. The goal is only
+ * to keep the numbers from being visible at a glance.
+ */
+
+const DEFAULT_SECRET = 'polly-planning-poker-vote-cipher-v1';
+const SECRET = process.env.NEXT_PUBLIC_VOTE_CIPHER_SECRET || DEFAULT_SECRET;
+const IV_LENGTH = 12;
+// Plaintext is padded to a fixed width so that every ciphertext has the same
+// length; otherwise "1" and "1.25" would be distinguishable by payload size.
+const PLAINTEXT_LENGTH = 16;
+
+let keyPromise: Promise<CryptoKey> | null = null;
+
+const getSubtle = (): SubtleCrypto => {
+    const subtle = globalThis.crypto?.subtle;
+    if (!subtle) {
+        throw new Error('Web Crypto API is not available in this environment');
+    }
+    return subtle;
+};
+
+const getKey = (): Promise<CryptoKey> => {
+    if (!keyPromise) {
+        keyPromise = (async () => {
+            const subtle = getSubtle();
+            const digest = await subtle.digest('SHA-256', new TextEncoder().encode(SECRET));
+            return subtle.importKey('raw', digest, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
+        })();
+    }
+    return keyPromise;
+};
+
+const toBase64 = (bytes: Uint8Array): string => {
+    let binary = '';
+    bytes.forEach((byte) => {
+        binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
+};
+
+const fromBase64 = (base64: string): Uint8Array => {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+};
+
+export const encryptVote = async (value: number): Promise<string> => {
+    const subtle = getSubtle();
+    const key = await getKey();
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+    const encoded = new TextEncoder().encode(String(value).padEnd(PLAINTEXT_LENGTH, ' '));
+    const cipher = new Uint8Array(await subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded));
+
+    const payload = new Uint8Array(iv.length + cipher.length);
+    payload.set(iv, 0);
+    payload.set(cipher, iv.length);
+
+    return toBase64(payload);
+};
+
+export const decryptVote = async (encrypted: string | null | undefined): Promise<number | null> => {
+    if (!encrypted) {
+        return null;
+    }
+    try {
+        const subtle = getSubtle();
+        const key = await getKey();
+        const payload = fromBase64(encrypted);
+        const iv = payload.slice(0, IV_LENGTH);
+        const cipher = payload.slice(IV_LENGTH);
+        const plain = new TextDecoder().decode(await subtle.decrypt({ name: 'AES-GCM', iv }, key, cipher));
+        const trimmed = plain.trim();
+        const value = trimmed === '' ? NaN : Number(trimmed);
+        return isNumber(value) ? value : null;
+    } catch (error) {
+        console.error('Failed to decrypt vote value', error);
+        return null;
+    }
+};
+
+/**
+ * Resolves the plain numeric `value` of a `UsersOnStories` row: decrypts
+ * `encrypted_value` when present, otherwise falls back to the legacy plain
+ * `value` column (rows created before encryption was introduced).
+ */
+export const decodeUserOnStory = async (row: UserOnStory): Promise<UserOnStory> => {
+    if (row.encrypted_value) {
+        return { ...row, value: await decryptVote(row.encrypted_value) };
+    }
+    return row;
+};
+
+export const decodeUsersOnStory = (rows: UserOnStory[]): Promise<UserOnStory[]> => {
+    return Promise.all(rows.map(decodeUserOnStory));
+};

--- a/supabase/migrations/20260903120000_add_encrypted_value_to_users_on_stories.sql
+++ b/supabase/migrations/20260903120000_add_encrypted_value_to_users_on_stories.sql
@@ -1,0 +1,6 @@
+-- Votes are now stored encrypted on the client side so that the raw numbers
+-- are not readable from the realtime websocket / REST payloads in devtools.
+-- The plain "value" column is kept for backwards compatibility with old rows
+-- and is no longer written by the app.
+ALTER TABLE "public"."UsersOnStories"
+ADD COLUMN "encrypted_value" text;

--- a/supabase/migrations/20260903120000_add_encrypted_value_to_users_on_stories.sql
+++ b/supabase/migrations/20260903120000_add_encrypted_value_to_users_on_stories.sql
@@ -3,4 +3,4 @@
 -- The plain "value" column is kept for backwards compatibility with old rows
 -- and is no longer written by the app.
 ALTER TABLE "public"."UsersOnStories"
-ADD COLUMN "encrypted_value" text;
+ADD COLUMN IF NOT EXISTS "encrypted_value" text;


### PR DESCRIPTION
## Summary
Implements client-side AES-GCM encryption for vote values to prevent them from being readable in browser devtools (websocket frames and REST responses). Votes are now stored encrypted in a new `encrypted_value` column while maintaining backward compatibility with legacy unencrypted `value` entries.

## Key Changes
- **New `voteCipher.ts` utility**: Provides `encryptVote()` and `decryptVote()` functions using Web Crypto API with AES-GCM. Includes helper functions to decode `UserOnStory` rows and handle both encrypted and legacy plaintext votes.
- **Database migration**: Adds `encrypted_value` text column to `UsersOnStories` table for storing encrypted votes
- **Vote submission**: `selectTime()` now encrypts votes before storing, setting plain `value` to null
- **Vote retrieval**: Updated `getStory()`, `getUsersOnStory()`, and realtime handlers to decrypt votes using `decodeUsersOnStory()` and `decodeUserOnStory()`
- **Auto-complete endpoint**: Updated to query both `value` and `encrypted_value` columns when checking if all users have voted
- **Type definitions**: Updated `database.types.ts` to include `encrypted_value` field

## Implementation Details
- Uses SHA-256 digest of a configurable secret (via `NEXT_PUBLIC_VOTE_CIPHER_SECRET` env var) as the AES-GCM key
- Generates a random 12-byte IV for each encryption, ensuring identical votes produce different ciphertexts
- Pads plaintext to fixed 16-character width so ciphertext length doesn't leak vote magnitude
- Encodes IV + ciphertext as base64 for storage
- Intentionally NOT a security boundary—the key is in the client bundle. Goal is only to prevent casual inspection in devtools.
- Gracefully handles decryption failures and maintains backward compatibility with unencrypted legacy rows

https://claude.ai/code/session_01N2GSkfYH1BCm9msvCEESUx